### PR TITLE
Proposal implementation of IOResource

### DIFF
--- a/core/src/main/java/org/htsjdk/core/io/IOResource.java
+++ b/core/src/main/java/org/htsjdk/core/io/IOResource.java
@@ -1,0 +1,19 @@
+package org.htsjdk.core.io;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * IO resource for HTSJDK.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public interface IOResource<READER, WRITER> {
+
+    public String uriIdentifier();
+
+    public READER openReader() throws IOException;
+
+    public WRITER openWriter() throws IOException;
+
+}

--- a/core/src/main/java/org/htsjdk/core/io/IOResourceFactory.java
+++ b/core/src/main/java/org/htsjdk/core/io/IOResourceFactory.java
@@ -1,0 +1,73 @@
+package org.htsjdk.core.io;
+
+import org.htsjdk.core.io.internal.PathResourceProvider;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public final class IOResourceFactory {
+
+    // installed providers
+    private static volatile List<IOResourceProvider<?, ?>> installedProviders;
+
+    public static final void registerProvider(final IOResourceProvider<?, ?> provider) {
+        if (provider.uriIdentifier().equalsIgnoreCase(PathResourceProvider.INSTANCE.uriIdentifier())) {
+            throw new IllegalArgumentException();
+        }
+        getLoadedProviders().add(provider);
+    }
+
+    private static final List<IOResourceProvider<?, ?>> getLoadedProviders() {
+        if (installedProviders == null) {
+            ServiceLoader<IOResourceProvider> sl = ServiceLoader
+                    .load(IOResourceProvider.class, ClassLoader.getSystemClassLoader());
+
+            for (IOResourceProvider provider: sl) {
+
+                final String identifier = provider.uriIdentifier();
+
+                // register if it is not the default
+                if (!identifier.equalsIgnoreCase(PathResourceProvider.INSTANCE.uriIdentifier())) {
+                    // first one takes effec
+                    installedProviders.add(provider);
+                }
+            }
+        }
+        return installedProviders;
+    }
+
+    public static final IOResource<InputStream, OutputStream> getDefault(final String resourceString) {
+        return PathResourceProvider.INSTANCE.create(resourceString);
+    }
+
+    public static final IOResource<InputStream, OutputStream> getDefault(final URI resourceUri) {
+        return PathResourceProvider.INSTANCE.create(resourceUri);
+    }
+
+    public IOResource<?, ?> get(final String resourceString) {
+        try {
+            return get(new URI(resourceString));
+        } catch (final URISyntaxException e) {
+            // try to use the default
+            return getDefault(resourceString);
+        }
+    }
+
+    public IOResource<?, ?> get(final URI resourceUri) {
+        if (resourceUri.getScheme() != null) {
+            for (final IOResourceProvider<?, ?> provider: getLoadedProviders()) {
+                if (resourceUri.getScheme().equalsIgnoreCase(provider.uriIdentifier())) {
+                    return provider.create(resourceUri);
+                }
+            }
+        }
+        return getDefault(resourceUri);
+    }
+}

--- a/core/src/main/java/org/htsjdk/core/io/IOResourceProvider.java
+++ b/core/src/main/java/org/htsjdk/core/io/IOResourceProvider.java
@@ -1,0 +1,17 @@
+package org.htsjdk.core.io;
+
+import java.net.URI;
+
+/**
+ * Service class.
+ *
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public interface IOResourceProvider<READER, WRITER> {
+
+    public String uriIdentifier();
+
+    public IOResource<READER, WRITER> create(final String resourceString);
+
+	public IOResource<READER, WRITER> create(final URI resourceUri);
+}

--- a/core/src/main/java/org/htsjdk/core/io/internal/PathResource.java
+++ b/core/src/main/java/org/htsjdk/core/io/internal/PathResource.java
@@ -1,0 +1,37 @@
+package org.htsjdk.core.io.internal;
+
+import org.htsjdk.core.io.IOResource;
+import org.htsjdk.core.io.IOResourceFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+class PathResource implements IOResource<InputStream, OutputStream> {
+
+    private final Path path;
+
+    PathResource(final Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public String uriIdentifier() {
+        return PathResourceProvider.INSTANCE.uriIdentifier();
+    }
+
+    @Override
+    public InputStream openReader() throws IOException {
+        return Files.newInputStream(path);
+    }
+
+    @Override
+    public OutputStream openWriter() throws IOException {
+        return Files.newOutputStream(path);
+    }
+}

--- a/core/src/main/java/org/htsjdk/core/io/internal/PathResourceProvider.java
+++ b/core/src/main/java/org/htsjdk/core/io/internal/PathResourceProvider.java
@@ -1,0 +1,36 @@
+package org.htsjdk.core.io.internal;
+
+import org.htsjdk.core.io.IOResource;
+import org.htsjdk.core.io.IOResourceFactory;
+import org.htsjdk.core.io.IOResourceProvider;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Paths;
+
+/**
+ * @author Daniel Gomez-Sanchez (magicDGS)
+ */
+public class PathResourceProvider implements IOResourceProvider<InputStream, OutputStream> {
+
+    public static final PathResourceProvider INSTANCE = new PathResourceProvider();
+
+    // singleton
+    private PathResourceProvider() {}
+
+    @Override
+    public String uriIdentifier() {
+        return "file"; // files are always handled by java.nio.Path
+    }
+
+    @Override
+    public IOResource<InputStream, OutputStream> create(String resourceString) {
+        return new PathResource(Paths.get(resourceString));
+    }
+
+    @Override
+    public IOResource<InputStream, OutputStream> create(URI resourceUri) {
+        return new PathResource(Paths.get(resourceUri));
+    }
+}


### PR DESCRIPTION
Following the discussion today, I did some changes to the idea in #42 and provide an implementation instead of a document to show my point. The idea is:

* Each resource is identified by the URI scheme. `file`/`null` schemes are reserved for default, which is `java.nio.Path`. This has the following advantages:
  * Non-path resources can include a Path handled by `java.nio.Path`. For example, an use case is the GenomicDB, that could be specified as `gendb:hdfs://${path}` or `gendb:${local_path}` or SRA accessions/files.
  * Supports windows paths, which cannot be converted to URI
  * Out-of-the-box support for installed `FileSystemProviders`
* Each resource has the responsibility of define how they read/write the data. This is designed as a low-level abstraction to hide the implementation, and most of the library users will not require to cast the interfaces.
* Resources should be retrieved **ONLY** through the `IOResourceFactory` get methods. Registering of `IOResourceProvider` could be done by either the service API or directly in the factory. Default implementation (`java.nio.Path`) is not exposed, and could not be overwriten. This allows to fallback to the `java.nio.Path` in every case, and to be flexible enough to get users define their own providers.

A custom implementation of an `IOResource` might look as this:

```java
public SRAAccession implements IOResource<SRAReader, Object> {
    private final String accNumber;
    public void SRAResource(final String accNumber) { this.accNumber = accNumber; };
    public String uriIdentifier() { return "sra" };
    public SRAReader openReader() throws IOException { return new SRAReader(accNumber) };
    public Object openWriter() throws IOException { throws IOException("Accession cannot be overwritten") };
```

And a consumer will use it in this way (too many assumptions in this case, because we don't have any idea on how we will implement the high-level record interfaces, but the reader/writer will take care if the `IOResource` - scheme and/or input/output):

```java
final RecordReader<Read> readerBuilder = new RecordReaderBuilder(Read.class)
                                          .addReadsSource(IOResourceFactory.get("sra:SRA011223"))
                                          .build();
```

```java
final RecordReader<Read> readerBuilder = new RecordReaderBuilder(Read.class)
                                          .addReadsSource(IOResourceFactory.get("~/reads/sample1.cram"))
                                          .addRefereceSource(IOResourceFactory.get("hdfs://example.com/references/hg19.fasta")
                                          .build();
```

This is the alternative that I have in mind instead of #34.